### PR TITLE
Fix package entrypoint imports and add app paths

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,20 +1,28 @@
 import sys
-from PyQt5 import QtWidgets
-from app.utils.logging_setup import setup_logging, hook_qt_messages
-from utils.settings import load_settings
-from utils.theme_guard import apply_theme
+from PyQt5 import QtCore, QtWidgets
+from SmartDoctorOrganizerAgent.utils.logging_setup import setup_logging, hook_qt_messages
+from SmartDoctorOrganizerAgent.utils.settings import load_settings
+from SmartDoctorOrganizerAgent.utils.theme_guard import ensure_theme
+from SmartDoctorOrganizerAgent.main import main as run_main
 
 def main() -> int:
     setup_logging()
     hook_qt_messages()
 
     app = QtWidgets.QApplication(sys.argv)
-    s = load_settings()
-    apply_theme(app, mode=s.theme_mode, base_point_size=s.base_point_size, rtl=s.rtl)
+    settings = load_settings()
 
-    # your existing window creation
-    from app.main import main as run_main
-    return run_main(app)  # refactor main.py to expose main(app) -> int
+    if settings.base_point_size:
+        font = app.font()
+        font.setPointSize(settings.base_point_size)
+        app.setFont(font)
+
+    app.setLayoutDirection(
+        QtCore.Qt.RightToLeft if settings.rtl else QtCore.Qt.LeftToRight
+    )
+
+    ensure_theme(app)
+    return run_main(app)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/home_page.py
+++ b/home_page.py
@@ -5,7 +5,28 @@ from pathlib import Path
 import importlib, importlib.util, importlib.machinery
 
 from PyQt5 import QtCore, QtGui, QtWidgets, QtSvg
-from Tabs.chatbot_tab import ChatBotTab
+
+if __package__:
+    try:
+        from .Tabs.chatbot_tab import ChatBotTab
+    except Exception:
+        ChatBotTab = None  # type: ignore[assignment]
+else:
+    try:
+        from Tabs.chatbot_tab import ChatBotTab  # type: ignore[assignment]
+    except Exception:
+        ChatBotTab = None  # type: ignore[assignment]
+
+if ChatBotTab is None:
+    class ChatBotTab(QtWidgets.QWidget):
+        def __init__(self, *_, **__):
+            super().__init__()
+            layout = QtWidgets.QVBoxLayout(self)
+            msg = QtWidgets.QLabel(
+                "ChatBot module unavailable (missing optional dependencies)."
+            )
+            msg.setWordWrap(True)
+            layout.addWidget(msg)
 
 ROOT = Path(__file__).resolve().parent
 

--- a/main.py
+++ b/main.py
@@ -2,8 +2,30 @@ from __future__ import annotations
 import importlib, importlib.util, sys, types, traceback, base64
 from typing import List, Optional, Tuple, Sequence
 from PyQt5 import QtCore, QtGui, QtWidgets, QtSvg
-from Tabs.chatbot_tab import ChatBotTab
-from home_page import _resolve_hf_snapshot_dir
+
+if __package__:
+    try:
+        from .Tabs.chatbot_tab import ChatBotTab
+    except Exception:
+        ChatBotTab = None  # type: ignore[assignment]
+    from .home_page import _resolve_hf_snapshot_dir
+else:
+    try:
+        from Tabs.chatbot_tab import ChatBotTab  # type: ignore[assignment]
+    except Exception:
+        ChatBotTab = None  # type: ignore[assignment]
+    from home_page import _resolve_hf_snapshot_dir
+
+if ChatBotTab is None:
+    class ChatBotTab(QtWidgets.QWidget):
+        def __init__(self, *_, **__):
+            super().__init__()
+            layout = QtWidgets.QVBoxLayout(self)
+            msg = QtWidgets.QLabel(
+                "ChatBot module unavailable (missing optional dependencies)."
+            )
+            msg.setWordWrap(True)
+            layout.addWidget(msg)
 
 
 def _ensure_translation_helper():
@@ -455,10 +477,12 @@ class HomePage(QtWidgets.QWidget):
         self._floating_windows.append(dlg)
         dlg.show()
 
-if __name__ == "__main__":
-    import sys
-    app = QtWidgets.QApplication(sys.argv)
-    # make sure global theme is applied
+def main(app: Optional[QtWidgets.QApplication] = None) -> int:
+    """Launch the primary UI window and start the Qt event loop."""
+
+    if app is None:
+        app = QtWidgets.QApplication(sys.argv)
+
     try:
         from UI import design_system
 
@@ -488,4 +512,10 @@ if __name__ == "__main__":
         print("[main] LLM configure error:", e)
         traceback.print_exc()
 
-    sys.exit(app.exec_())
+    return app.exec_()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/utils/app_paths.py
+++ b/utils/app_paths.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_APP_DIR_NAME = "smartdoctororganizer"
+
+
+def _ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def base_dir() -> Path:
+    """Return the root directory used for storing user data and logs."""
+    return _ensure_dir(Path.home() / f".{_APP_DIR_NAME}")
+
+
+def user_data_dir() -> Path:
+    """Directory that stores user editable data such as settings."""
+    return _ensure_dir(base_dir() / "data")
+
+
+def logs_dir() -> Path:
+    """Directory that stores rotating log files."""
+    return _ensure_dir(base_dir() / "logs")
+
+
+def cache_dir() -> Path:
+    """Cache directory for temporary files."""
+    return _ensure_dir(base_dir() / "cache")
+
+
+__all__ = [
+    "base_dir",
+    "user_data_dir",
+    "logs_dir",
+    "cache_dir",
+]


### PR DESCRIPTION
## Summary
- update the package entrypoint to import the in-repo helpers and apply stored settings when creating the QApplication
- add a simple utils.app_paths module used by logging and settings to create user data and log directories
- refactor main and home_page imports so the package runs as a module and provide a fallback ChatBotTab when optional dependencies are missing

## Testing
- QT_QPA_PLATFORM=offscreen python -m SmartDoctorOrganizerAgent

------
https://chatgpt.com/codex/tasks/task_e_68ca81a2af8083289f6ba3538380c9e6