### PR TITLE
Remove eager gemma import from extraction tab

### DIFF
--- a/Tabs/extraction_tab.py
+++ b/Tabs/extraction_tab.py
@@ -22,7 +22,6 @@ import json
 import tempfile
 from datetime import datetime, timedelta
 from typing import Callable, Dict, List, Tuple, Optional
-from nlp.local_gemma_it import extract_fields
 from PyQt5 import QtWidgets, QtCore, QtGui
 try:
     from nlp.local_gemma_it import extract_fields as _gemma_extract


### PR DESCRIPTION
## Summary
- remove the unconditional import of the local Gemma extractor so the optional try/except gate controls access to it

## Testing
- python - <<'PY'
import importlib
mod = importlib.import_module('Tabs.extraction_tab')
print('Imported', mod.__name__)
print('Gemma extractor?', getattr(mod, '_gemma_extract'))
print('Smart extractor?', getattr(mod, '_EXTRACTOR'))
PY
- QT_QPA_PLATFORM=offscreen python -m SmartDoctorOrganizerAgent *(fails: missing Gemma snapshot, but no ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68ca97d17c6483289a4b80bc25182d69