### PR TITLE
Add SoundVoice voice recorder with manual controls

### DIFF
--- a/Tabs/extraction_tab.py
+++ b/Tabs/extraction_tab.py
@@ -22,7 +22,6 @@ import json
 import tempfile
 from datetime import datetime, timedelta
 from typing import Callable, Dict, List, Tuple, Optional
-from nlp.local_gemma_it import extract_fields
 from PyQt5 import QtWidgets, QtCore, QtGui
 try:
     from nlp.local_gemma_it import extract_fields as _gemma_extract

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ pyyaml>=6.0
 # Optional:
 faster-whisper>=1.0
 matplotlib>=3.8
+sounddevice>=0.4
 
 

--- a/speech/soundvoice.py
+++ b/speech/soundvoice.py
@@ -1,0 +1,139 @@
+"""Utility helpers for capturing microphone audio with manual control."""
+from __future__ import annotations
+
+import io
+import queue
+import threading
+import wave
+from dataclasses import dataclass
+from typing import List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import sounddevice as _sd
+except Exception:  # pragma: no cover - the widget will surface a friendly error
+    _sd = None
+
+SOUNDVOICE_OK = _sd is not None
+
+
+@dataclass
+class SoundVoiceStatus:
+    """Represents warnings or notes emitted by the recorder backend."""
+
+    message: str
+
+
+class SoundVoiceRecorder:
+    """High-level wrapper above ``sounddevice`` providing start/stop controls."""
+
+    def __init__(self, samplerate: int = 16_000, channels: int = 1):
+        self.samplerate = int(samplerate)
+        self.channels = int(channels)
+        self.dtype = "int16"
+        self._queue: "queue.Queue[Optional[bytes]]" = queue.Queue()
+        self._frames: List[bytes] = []
+        self._stream = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._running = False
+        self._status: List[SoundVoiceStatus] = []
+
+    @property
+    def status_messages(self) -> List[SoundVoiceStatus]:
+        """Return and clear backend status messages accumulated so far."""
+
+        with self._lock:
+            msgs = list(self._status)
+            self._status.clear()
+        return msgs
+
+    def _enqueue(self, data: Optional[bytes]):
+        try:
+            self._queue.put_nowait(data)
+        except queue.Full:  # pragma: no cover - should not occur, but guard anyway
+            pass
+
+    def start(self) -> None:
+        """Begin recording from the system microphone."""
+
+        if not SOUNDVOICE_OK:
+            raise RuntimeError("sounddevice is not available; install 'sounddevice' to enable SoundVoice.")
+        if self._running:
+            return
+
+        self._frames = []
+        self._queue = queue.Queue()
+        self._running = True
+
+        def _callback(indata, frames, time, status):  # pragma: no cover - callback executed by sounddevice
+            if status:
+                with self._lock:
+                    self._status.append(SoundVoiceStatus(str(status)))
+            self._enqueue(bytes(indata))
+
+        self._stream = _sd.RawInputStream(
+            samplerate=self.samplerate,
+            channels=self.channels,
+            dtype=self.dtype,
+            callback=_callback,
+            blocksize=0,
+        )
+        self._stream.start()
+        self._reader_thread = threading.Thread(target=self._drain_queue, daemon=True)
+        self._reader_thread.start()
+
+    def _drain_queue(self) -> None:
+        while self._running:
+            try:
+                chunk = self._queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if chunk is None:
+                break
+            with self._lock:
+                self._frames.append(chunk)
+
+    def stop(self) -> bytes:
+        """Stop recording and return raw PCM data."""
+
+        if not self._running:
+            return b""
+        self._running = False
+        if self._stream is not None:
+            try:
+                self._stream.stop()
+            finally:
+                self._stream.close()
+            self._stream = None
+        self._enqueue(None)
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=1.0)
+        self._reader_thread = None
+        with self._lock:
+            raw = b"".join(self._frames)
+            self._frames = []
+        return raw
+
+    def discard(self) -> None:
+        """Abort recording and drop buffered audio without returning it."""
+
+        self.stop()
+        with self._lock:
+            self._frames = []
+
+    def to_wav(self, raw: Optional[bytes]) -> bytes:
+        """Convert raw PCM bytes into a WAV byte stream."""
+
+        raw = raw or b""
+        if not raw:
+            return b""
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wf:
+            wf.setnchannels(self.channels)
+            wf.setsampwidth(2)  # int16
+            wf.setframerate(self.samplerate)
+            wf.writeframes(raw)
+        return buffer.getvalue()
+
+
+__all__ = ["SOUNDVOICE_OK", "SoundVoiceRecorder", "SoundVoiceStatus"]

--- a/widgets/voice_input_widget.py
+++ b/widgets/voice_input_widget.py
@@ -1,6 +1,9 @@
+import io
 import sys
 from PyQt5 import QtWidgets, QtCore, QtGui
 import speech_recognition as sr
+
+from speech.soundvoice import SOUNDVOICE_OK, SoundVoiceRecorder
 
 
 class VoiceInputWidget(QtWidgets.QWidget):
@@ -13,53 +16,137 @@ class VoiceInputWidget(QtWidgets.QWidget):
         """
         super().__init__(parent)
         self.language = language
+        self.recognizer = sr.Recognizer()
+        self.recorder = SoundVoiceRecorder()
+        self._recording = False
+        self._has_recorded = False
         self.setup_ui()
 
     def setup_ui(self):
         layout = QtWidgets.QVBoxLayout(self)
-        # Create a button and assign it to self.voice_button.
-        self.voice_button = QtWidgets.QPushButton("Voice Input")
+        layout.setSpacing(8)
+
+        self.voice_button = QtWidgets.QPushButton("Start Recording")
         self.voice_button.setFont(QtGui.QFont("Segoe UI", 14))
         self.voice_button.clicked.connect(self.start_voice_input)
         layout.addWidget(self.voice_button)
+
+        controls = QtWidgets.QHBoxLayout()
+        controls.setSpacing(8)
+
+        self.stop_button = QtWidgets.QPushButton("Stop")
+        self.stop_button.clicked.connect(self.stop_and_transcribe)
+        self.stop_button.setEnabled(False)
+        controls.addWidget(self.stop_button)
+
+        self.cancel_button = QtWidgets.QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.cancel_recording)
+        self.cancel_button.setEnabled(False)
+        controls.addWidget(self.cancel_button)
+
+        layout.addLayout(controls)
+
+        self.status_label = QtWidgets.QLabel("Tap Start to capture audio with SoundVoice.")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        if not SOUNDVOICE_OK:
+            self.status_label.setText("SoundVoice requires the optional 'sounddevice' package.")
+
         self.setLayout(layout)
 
     def start_voice_input(self):
-        # Use self.voice_button (not self.record_button) to update the text.
-        self.voice_button.setText("Listening...")
+        if self._recording:
+            return
+        if not SOUNDVOICE_OK:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "SoundVoice",
+                "SoundVoice is unavailable. Install the 'sounddevice' package to enable recording.",
+            )
+            return
+        try:
+            self.recorder.start()
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", f"Could not start recording: {e}")
+            return
+
+        self._recording = True
+        self.voice_button.setEnabled(False)
+        self.stop_button.setEnabled(True)
+        self.cancel_button.setEnabled(True)
+        self.status_label.setText("Recording… press Stop when you are finished.")
+
+    def stop_and_transcribe(self):
+        self._finish_recording(finalize=True)
+
+    def cancel_recording(self):
+        self._finish_recording(finalize=False)
+
+    def _finish_recording(self, finalize: bool):
+        if not self._recording:
+            return
+        self.stop_button.setEnabled(False)
+        self.cancel_button.setEnabled(False)
+        QtWidgets.QApplication.processEvents()
+        try:
+            raw_audio = self.recorder.stop()
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", f"Could not stop recording: {e}")
+            raw_audio = b""
+        self._recording = False
+        self.voice_button.setEnabled(True)
+        next_label = "Continue Recording" if self._has_recorded else "Start Recording"
+        self.voice_button.setText(next_label)
+
+        if not finalize:
+            self.status_label.setText("Recording cancelled.")
+            return
+
+        wav_bytes = self.recorder.to_wav(raw_audio)
+        if not wav_bytes:
+            self.status_label.setText("No audio captured.")
+            QtWidgets.QMessageBox.information(self, "SoundVoice", "No audio detected. Try recording again.")
+            return
+
+        self.status_label.setText("Transcribing…")
         QtWidgets.QApplication.processEvents()
 
-        r = sr.Recognizer()
+        for status in self.recorder.status_messages:
+            print(f"SoundVoice status: {status.message}")
+
         try:
-            with sr.Microphone() as source:
-                print("Adjusting for ambient noise...")
-                r.adjust_for_ambient_noise(source, duration=0.5)
-                print("Listening for speech (timeout=7 seconds)...")
-                audio = r.listen(source, timeout=7)
-                print("Recognizing speech...")
-                text = r.recognize_google(audio, language=self.language)
-                print(f"Recognized text: {text}")
-                # Emit the recognized text.
-                self.textReady.emit(text)
-                # Reset button text.
-                self.voice_button.setText("Voice Input")
+            with sr.AudioFile(io.BytesIO(wav_bytes)) as source:
+                audio = self.recognizer.record(source)
+            text = self.recognizer.recognize_google(audio, language=self.language)
         except sr.WaitTimeoutError:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error", "Listening timed out. Please try again.")
-            print("Error: WaitTimeoutError")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("Listening timed out.")
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", "Listening timed out. Please try again.")
+            return
         except sr.UnknownValueError:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error",
-                                          "Could not understand the audio. Please speak clearly.")
-            print("Error: UnknownValueError")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("Could not understand the audio.")
+            QtWidgets.QMessageBox.warning(
+                self,
+                "SoundVoice",
+                "Could not understand the audio. Please speak clearly.",
+            )
+            return
         except sr.RequestError as e:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error", f"Could not request results; {e}")
-            print(f"Error: RequestError: {e}")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("Service unavailable.")
+            QtWidgets.QMessageBox.warning(
+                self,
+                "SoundVoice",
+                f"Could not request results from the speech service: {e}",
+            )
+            return
         except Exception as e:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error", f"An unexpected error occurred: {e}")
-            print(f"Unexpected error: {e}")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("An unexpected error occurred.")
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", f"An unexpected error occurred: {e}")
+            return
+
+        self._has_recorded = True
+        self.status_label.setText("Transcription complete.")
+        self.textReady.emit(text)
 
 
 # ------------------- Example Usage -------------------
@@ -69,18 +156,15 @@ if __name__ == "__main__":
     window = QtWidgets.QWidget()
     layout = QtWidgets.QVBoxLayout(window)
 
-    # Create a VoiceInputWidget (set language as desired; "en-US" for English, "ar-SA" for Arabic)
     voice_widget = VoiceInputWidget(language="en-US")
     layout.addWidget(voice_widget)
 
-    # Create a QTextEdit to display the recognized text.
     text_edit = QtWidgets.QTextEdit()
     layout.addWidget(text_edit)
 
-    # Connect the textReady signal to update the text edit.
     voice_widget.textReady.connect(lambda text: text_edit.setPlainText(text))
 
     window.setWindowTitle("Voice Input Demo")
-    window.resize(400, 300)
+    window.resize(400, 320)
     window.show()
     sys.exit(app.exec_())


### PR DESCRIPTION
## Summary
- add a SoundVoice recorder helper backed by sounddevice for manual microphone control
- update the voice input widget to use SoundVoice with explicit start/stop/cancel actions and status feedback
- document the optional sounddevice dependency in requirements

## Testing
- python -m compileall SmartDoctorOrganizerAgent/speech/soundvoice.py SmartDoctorOrganizerAgent/widgets/voice_input_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68ca97d17c6483289a4b80bc25182d69