### PR TITLE
Refine voice recorder button styling and controls

### DIFF
--- a/SmartDoctorOrganizerAgent/__init__.py
+++ b/SmartDoctorOrganizerAgent/__init__.py
@@ -1,0 +1,24 @@
+"""Package bootstrap for SmartDoctorOrganizerAgent.
+
+This package wrapper ensures the project modules that live at the
+repository root remain importable via the ``SmartDoctorOrganizerAgent``
+package namespace.  By appending the repository root to ``__path__`` we
+allow imports such as ``SmartDoctorOrganizerAgent.utils`` or
+``SmartDoctorOrganizerAgent.main`` to resolve without requiring the
+project to be installed as a site package.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# When the package is imported, ``__path__`` already contains the
+# directory for ``SmartDoctorOrganizerAgent``.  We extend it with the
+# repository root so that submodules located next to this package (for
+# example ``utils`` or ``main``) can still be resolved as package
+# imports.
+_project_root = Path(__file__).resolve().parent.parent
+_root_str = str(_project_root)
+if _root_str not in __path__:
+    __path__.append(_root_str)
+
+del _project_root, _root_str

--- a/SmartDoctorOrganizerAgent/__main__.py
+++ b/SmartDoctorOrganizerAgent/__main__.py
@@ -1,0 +1,41 @@
+"""Executable module for ``python -m SmartDoctorOrganizerAgent``."""
+from __future__ import annotations
+
+import sys
+
+from PyQt5 import QtCore, QtWidgets
+
+from .utils.logging_setup import hook_qt_messages, setup_logging
+from .utils.settings import load_settings
+from .utils.theme_guard import ensure_theme
+from .main import main as run_main
+
+
+def main() -> int:
+    """Launch the SmartDoctorOrganizerAgent Qt application."""
+    setup_logging()
+    hook_qt_messages()
+
+    app = QtWidgets.QApplication(sys.argv)
+    settings = load_settings()
+
+    if settings.base_point_size:
+        font = app.font()
+        font.setPointSize(settings.base_point_size)
+        app.setFont(font)
+
+    app.setLayoutDirection(
+        QtCore.Qt.RightToLeft if settings.rtl else QtCore.Qt.LeftToRight
+    )
+
+    ensure_theme(app)
+    return run_main(app)
+
+
+def _main() -> int:
+    """Private helper to preserve backwards compatibility."""
+    return main()
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    sys.exit(main())

--- a/Tabs/extraction_tab.py
+++ b/Tabs/extraction_tab.py
@@ -22,7 +22,6 @@ import json
 import tempfile
 from datetime import datetime, timedelta
 from typing import Callable, Dict, List, Tuple, Optional
-from nlp.local_gemma_it import extract_fields
 from PyQt5 import QtWidgets, QtCore, QtGui
 try:
     from nlp.local_gemma_it import extract_fields as _gemma_extract

--- a/__main__.py
+++ b/__main__.py
@@ -1,28 +1,9 @@
+"""Backward-compatible launcher for SmartDoctorOrganizerAgent."""
+from __future__ import annotations
+
 import sys
-from PyQt5 import QtCore, QtWidgets
-from SmartDoctorOrganizerAgent.utils.logging_setup import setup_logging, hook_qt_messages
-from SmartDoctorOrganizerAgent.utils.settings import load_settings
-from SmartDoctorOrganizerAgent.utils.theme_guard import ensure_theme
-from SmartDoctorOrganizerAgent.main import main as run_main
 
-def main() -> int:
-    setup_logging()
-    hook_qt_messages()
+from SmartDoctorOrganizerAgent.__main__ import _main as main
 
-    app = QtWidgets.QApplication(sys.argv)
-    settings = load_settings()
-
-    if settings.base_point_size:
-        font = app.font()
-        font.setPointSize(settings.base_point_size)
-        app.setFont(font)
-
-    app.setLayoutDirection(
-        QtCore.Qt.RightToLeft if settings.rtl else QtCore.Qt.LeftToRight
-    )
-
-    ensure_theme(app)
-    return run_main(app)
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - module entry point
     sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ pyyaml>=6.0
 # Optional:
 faster-whisper>=1.0
 matplotlib>=3.8
+sounddevice>=0.4
 
 

--- a/speech/soundvoice.py
+++ b/speech/soundvoice.py
@@ -130,10 +130,12 @@ class SoundVoiceRecorder:
         self._reader_thread = None
 
     def _drain_queue(self) -> None:
-        while self._running:
+        while True:
             try:
                 chunk = self._queue.get(timeout=0.5)
             except queue.Empty:
+                if not self._running:
+                    break
                 continue
             if chunk is None:
                 break

--- a/speech/soundvoice.py
+++ b/speech/soundvoice.py
@@ -1,0 +1,139 @@
+"""Utility helpers for capturing microphone audio with manual control."""
+from __future__ import annotations
+
+import io
+import queue
+import threading
+import wave
+from dataclasses import dataclass
+from typing import List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import sounddevice as _sd
+except Exception:  # pragma: no cover - the widget will surface a friendly error
+    _sd = None
+
+SOUNDVOICE_OK = _sd is not None
+
+
+@dataclass
+class SoundVoiceStatus:
+    """Represents warnings or notes emitted by the recorder backend."""
+
+    message: str
+
+
+class SoundVoiceRecorder:
+    """High-level wrapper above ``sounddevice`` providing start/stop controls."""
+
+    def __init__(self, samplerate: int = 16_000, channels: int = 1):
+        self.samplerate = int(samplerate)
+        self.channels = int(channels)
+        self.dtype = "int16"
+        self._queue: "queue.Queue[Optional[bytes]]" = queue.Queue()
+        self._frames: List[bytes] = []
+        self._stream = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._running = False
+        self._status: List[SoundVoiceStatus] = []
+
+    @property
+    def status_messages(self) -> List[SoundVoiceStatus]:
+        """Return and clear backend status messages accumulated so far."""
+
+        with self._lock:
+            msgs = list(self._status)
+            self._status.clear()
+        return msgs
+
+    def _enqueue(self, data: Optional[bytes]):
+        try:
+            self._queue.put_nowait(data)
+        except queue.Full:  # pragma: no cover - should not occur, but guard anyway
+            pass
+
+    def start(self) -> None:
+        """Begin recording from the system microphone."""
+
+        if not SOUNDVOICE_OK:
+            raise RuntimeError("sounddevice is not available; install 'sounddevice' to enable SoundVoice.")
+        if self._running:
+            return
+
+        self._frames = []
+        self._queue = queue.Queue()
+        self._running = True
+
+        def _callback(indata, frames, time, status):  # pragma: no cover - callback executed by sounddevice
+            if status:
+                with self._lock:
+                    self._status.append(SoundVoiceStatus(str(status)))
+            self._enqueue(bytes(indata))
+
+        self._stream = _sd.RawInputStream(
+            samplerate=self.samplerate,
+            channels=self.channels,
+            dtype=self.dtype,
+            callback=_callback,
+            blocksize=0,
+        )
+        self._stream.start()
+        self._reader_thread = threading.Thread(target=self._drain_queue, daemon=True)
+        self._reader_thread.start()
+
+    def _drain_queue(self) -> None:
+        while self._running:
+            try:
+                chunk = self._queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if chunk is None:
+                break
+            with self._lock:
+                self._frames.append(chunk)
+
+    def stop(self) -> bytes:
+        """Stop recording and return raw PCM data."""
+
+        if not self._running:
+            return b""
+        self._running = False
+        if self._stream is not None:
+            try:
+                self._stream.stop()
+            finally:
+                self._stream.close()
+            self._stream = None
+        self._enqueue(None)
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=1.0)
+        self._reader_thread = None
+        with self._lock:
+            raw = b"".join(self._frames)
+            self._frames = []
+        return raw
+
+    def discard(self) -> None:
+        """Abort recording and drop buffered audio without returning it."""
+
+        self.stop()
+        with self._lock:
+            self._frames = []
+
+    def to_wav(self, raw: Optional[bytes]) -> bytes:
+        """Convert raw PCM bytes into a WAV byte stream."""
+
+        raw = raw or b""
+        if not raw:
+            return b""
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wf:
+            wf.setnchannels(self.channels)
+            wf.setsampwidth(2)  # int16
+            wf.setframerate(self.samplerate)
+            wf.writeframes(raw)
+        return buffer.getvalue()
+
+
+__all__ = ["SOUNDVOICE_OK", "SoundVoiceRecorder", "SoundVoiceStatus"]

--- a/widgets/voice_input_widget.py
+++ b/widgets/voice_input_widget.py
@@ -1,6 +1,9 @@
+import io
 import sys
 from PyQt5 import QtWidgets, QtCore, QtGui
 import speech_recognition as sr
+
+from speech.soundvoice import SOUNDVOICE_OK, SoundVoiceRecorder
 
 
 class VoiceInputWidget(QtWidgets.QWidget):
@@ -13,53 +16,202 @@ class VoiceInputWidget(QtWidgets.QWidget):
         """
         super().__init__(parent)
         self.language = language
+        self.recognizer = sr.Recognizer()
+        self.recorder = SoundVoiceRecorder()
+        self._recording = False
+        self._has_recorded = False
         self.setup_ui()
 
     def setup_ui(self):
         layout = QtWidgets.QVBoxLayout(self)
-        # Create a button and assign it to self.voice_button.
-        self.voice_button = QtWidgets.QPushButton("Voice Input")
-        self.voice_button.setFont(QtGui.QFont("Segoe UI", 14))
-        self.voice_button.clicked.connect(self.start_voice_input)
+        layout.setSpacing(8)
+
+        self.voice_button = QtWidgets.QPushButton()
+        self.voice_button.setObjectName("voiceButton")
+        self.voice_button.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
+        self.voice_button.setIconSize(QtCore.QSize(32, 32))
+        self.voice_button.setMinimumHeight(72)
+        self.voice_button.setCheckable(True)
+        self.voice_button.clicked.connect(self._on_record_button_clicked)
+        self._apply_record_button_style()
+        self._set_record_button_state(recording=False)
         layout.addWidget(self.voice_button)
+
+        controls = QtWidgets.QHBoxLayout()
+        controls.setSpacing(8)
+
+        self.stop_button = QtWidgets.QPushButton("Stop")
+        self.stop_button.clicked.connect(self.stop_and_transcribe)
+        self.stop_button.setEnabled(False)
+        controls.addWidget(self.stop_button)
+
+        self.cancel_button = QtWidgets.QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.cancel_recording)
+        self.cancel_button.setEnabled(False)
+        controls.addWidget(self.cancel_button)
+
+        layout.addLayout(controls)
+
+        self.status_label = QtWidgets.QLabel("Tap Start to capture audio with SoundVoice.")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        if not SOUNDVOICE_OK:
+            self.status_label.setText("SoundVoice requires the optional 'sounddevice' package.")
+
         self.setLayout(layout)
 
     def start_voice_input(self):
-        # Use self.voice_button (not self.record_button) to update the text.
-        self.voice_button.setText("Listening...")
+        if self._recording:
+            return
+        if not SOUNDVOICE_OK:
+            self.voice_button.setChecked(False)
+            QtWidgets.QMessageBox.warning(
+                self,
+                "SoundVoice",
+                "SoundVoice is unavailable. Install the 'sounddevice' package to enable recording.",
+            )
+            return
+        try:
+            self.recorder.start()
+        except Exception as e:
+            self.voice_button.setChecked(False)
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", f"Could not start recording: {e}")
+            return
+
+        self._recording = True
+        self.voice_button.setEnabled(True)
+        self.voice_button.setChecked(True)
+        self.stop_button.setEnabled(True)
+        self.cancel_button.setEnabled(True)
+        self._set_record_button_state(recording=True)
+        self.status_label.setText("Recording… press Stop when you are finished.")
+
+    def stop_and_transcribe(self):
+        self._finish_recording(finalize=True)
+
+    def cancel_recording(self):
+        self._finish_recording(finalize=False)
+
+    def _finish_recording(self, finalize: bool):
+        if not self._recording:
+            return
+        self.stop_button.setEnabled(False)
+        self.cancel_button.setEnabled(False)
+        QtWidgets.QApplication.processEvents()
+        try:
+            raw_audio = self.recorder.stop()
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", f"Could not stop recording: {e}")
+            raw_audio = b""
+        self._recording = False
+        self.voice_button.setEnabled(True)
+        self.voice_button.setChecked(False)
+        self._set_record_button_state(recording=False)
+
+        if not finalize:
+            self.status_label.setText("Recording cancelled.")
+            return
+
+        wav_bytes = self.recorder.to_wav(raw_audio)
+        if not wav_bytes:
+            self.status_label.setText("No audio captured.")
+            QtWidgets.QMessageBox.information(self, "SoundVoice", "No audio detected. Try recording again.")
+            return
+
+        self.status_label.setText("Transcribing…")
         QtWidgets.QApplication.processEvents()
 
-        r = sr.Recognizer()
+        for status in self.recorder.status_messages:
+            print(f"SoundVoice status: {status.message}")
+
         try:
-            with sr.Microphone() as source:
-                print("Adjusting for ambient noise...")
-                r.adjust_for_ambient_noise(source, duration=0.5)
-                print("Listening for speech (timeout=7 seconds)...")
-                audio = r.listen(source, timeout=7)
-                print("Recognizing speech...")
-                text = r.recognize_google(audio, language=self.language)
-                print(f"Recognized text: {text}")
-                # Emit the recognized text.
-                self.textReady.emit(text)
-                # Reset button text.
-                self.voice_button.setText("Voice Input")
+            with sr.AudioFile(io.BytesIO(wav_bytes)) as source:
+                audio = self.recognizer.record(source)
+            text = self.recognizer.recognize_google(audio, language=self.language)
         except sr.WaitTimeoutError:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error", "Listening timed out. Please try again.")
-            print("Error: WaitTimeoutError")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("Listening timed out.")
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", "Listening timed out. Please try again.")
+            return
         except sr.UnknownValueError:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error",
-                                          "Could not understand the audio. Please speak clearly.")
-            print("Error: UnknownValueError")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("Could not understand the audio.")
+            QtWidgets.QMessageBox.warning(
+                self,
+                "SoundVoice",
+                "Could not understand the audio. Please speak clearly.",
+            )
+            return
         except sr.RequestError as e:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error", f"Could not request results; {e}")
-            print(f"Error: RequestError: {e}")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("Service unavailable.")
+            QtWidgets.QMessageBox.warning(
+                self,
+                "SoundVoice",
+                f"Could not request results from the speech service: {e}",
+            )
+            return
         except Exception as e:
-            QtWidgets.QMessageBox.warning(self, "Voice Input Error", f"An unexpected error occurred: {e}")
-            print(f"Unexpected error: {e}")
-            self.voice_button.setText("Voice Input")
+            self.status_label.setText("An unexpected error occurred.")
+            QtWidgets.QMessageBox.warning(self, "SoundVoice", f"An unexpected error occurred: {e}")
+            return
+
+        self._has_recorded = True
+        self.status_label.setText("Transcription complete.")
+        self._set_record_button_state(recording=False)
+        self.textReady.emit(text)
+
+    def _on_record_button_clicked(self):
+        if self._recording:
+            self.stop_and_transcribe()
+        else:
+            self.start_voice_input()
+
+    def _set_record_button_state(self, recording: bool):
+        self.voice_button.setProperty("recording", recording)
+        mic_icon = QtGui.QIcon.fromTheme("audio-input-microphone")
+        if mic_icon.isNull():
+            mic_icon = self.style().standardIcon(QtWidgets.QStyle.SP_MediaRecord)
+        stop_icon = self.style().standardIcon(QtWidgets.QStyle.SP_MediaStop)
+        if recording:
+            self.voice_button.setText("Stop Recording")
+            self.voice_button.setIcon(stop_icon)
+        else:
+            label = "Continue Recording" if self._has_recorded else "Start Recording"
+            self.voice_button.setText(label)
+            self.voice_button.setIcon(mic_icon)
+        self.voice_button.style().unpolish(self.voice_button)
+        self.voice_button.style().polish(self.voice_button)
+
+    def _apply_record_button_style(self):
+        self.voice_button.setStyleSheet(
+            """
+            QPushButton#voiceButton {
+                border: none;
+                border-radius: 36px;
+                padding: 20px 32px;
+                font-size: 18px;
+                font-weight: 600;
+                letter-spacing: 0.5px;
+                color: #FFFFFF;
+                background-color: #1976D2;
+                qproperty-iconSize: 32px 32px;
+            }
+            QPushButton#voiceButton:hover {
+                background-color: #1565C0;
+            }
+            QPushButton#voiceButton:pressed {
+                background-color: #0D47A1;
+            }
+            QPushButton#voiceButton[recording="true"] {
+                background-color: #C62828;
+            }
+            QPushButton#voiceButton[recording="true"]:hover {
+                background-color: #B71C1C;
+            }
+            QPushButton#voiceButton[recording="true"]:pressed {
+                background-color: #7F0000;
+            }
+        """
+        )
 
 
 # ------------------- Example Usage -------------------
@@ -69,18 +221,15 @@ if __name__ == "__main__":
     window = QtWidgets.QWidget()
     layout = QtWidgets.QVBoxLayout(window)
 
-    # Create a VoiceInputWidget (set language as desired; "en-US" for English, "ar-SA" for Arabic)
     voice_widget = VoiceInputWidget(language="en-US")
     layout.addWidget(voice_widget)
 
-    # Create a QTextEdit to display the recognized text.
     text_edit = QtWidgets.QTextEdit()
     layout.addWidget(text_edit)
 
-    # Connect the textReady signal to update the text edit.
     voice_widget.textReady.connect(lambda text: text_edit.setPlainText(text))
 
     window.setWindowTitle("Voice Input Demo")
-    window.resize(400, 300)
+    window.resize(400, 320)
     window.show()
     sys.exit(app.exec_())

--- a/widgets/voice_input_widget.py
+++ b/widgets/voice_input_widget.py
@@ -42,6 +42,42 @@ class _TranscriptionWorker(QtCore.QObject):
             self.finished.emit(text)
 
 
+class _MicrophoneWorker(QtCore.QObject):
+    finished = QtCore.pyqtSignal(str)
+    failed = QtCore.pyqtSignal(str, str)
+
+    def __init__(self, language: str):
+        super().__init__()
+        self._language = language
+
+    @QtCore.pyqtSlot()
+    def run(self) -> None:
+        recognizer = sr.Recognizer()
+        try:
+            with sr.Microphone() as source:
+                recognizer.adjust_for_ambient_noise(source, duration=0.5)
+                audio = recognizer.listen(source, timeout=7, phrase_time_limit=30)
+            text = recognizer.recognize_google(audio, language=self._language)
+        except sr.WaitTimeoutError:
+            self.failed.emit("Listening timed out.", "Listening timed out. Please try again.")
+        except sr.UnknownValueError:
+            self.failed.emit(
+                "Could not understand the audio.",
+                "Could not understand the audio. Please speak clearly.",
+            )
+        except sr.RequestError as exc:
+            self.failed.emit(
+                "Service unavailable.",
+                f"Could not request results from the speech service: {exc}",
+            )
+        except OSError as exc:
+            self.failed.emit("Microphone unavailable.", f"Could not access the microphone: {exc}")
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            self.failed.emit("An unexpected error occurred.", str(exc))
+        else:
+            self.finished.emit(text)
+
+
 class VoiceInputWidget(QtWidgets.QWidget):
     # Signal to emit recognized text
     textReady = QtCore.pyqtSignal(str)
@@ -52,7 +88,8 @@ class VoiceInputWidget(QtWidgets.QWidget):
         """
         super().__init__(parent)
         self.language = language
-        self.recorder = SoundVoiceRecorder()
+        self._soundvoice_available = SOUNDVOICE_OK
+        self.recorder: Optional[SoundVoiceRecorder] = SoundVoiceRecorder() if SOUNDVOICE_OK else None
         self._session_active = False
         self._is_paused = False
         self._transcribing = False
@@ -73,38 +110,49 @@ class VoiceInputWidget(QtWidgets.QWidget):
         self.voice_button.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
         self.voice_button.setIconSize(QtCore.QSize(32, 32))
         self.voice_button.setMinimumHeight(72)
-        self.voice_button.setCheckable(True)
-        self.voice_button.clicked.connect(self._handle_primary_press)
+        self.voice_button.setCheckable(self._soundvoice_available)
+        if self._soundvoice_available:
+            self.voice_button.clicked.connect(self._handle_primary_press)
+        else:
+            self.voice_button.clicked.connect(self._start_basic_capture)
         self._apply_record_button_style()
         self._init_icons()
         self._set_record_button_state()
         layout.addWidget(self.voice_button)
 
-        controls = QtWidgets.QHBoxLayout()
-        controls.setSpacing(8)
+        self.stop_button: Optional[QtWidgets.QPushButton]
+        self.cancel_button: Optional[QtWidgets.QPushButton]
+        if self._soundvoice_available:
+            controls = QtWidgets.QHBoxLayout()
+            controls.setSpacing(8)
 
-        self.stop_button = QtWidgets.QPushButton("Stop")
-        self.stop_button.setIcon(self.style().standardIcon(QtWidgets.QStyle.SP_MediaStop))
-        self.stop_button.setIconSize(QtCore.QSize(24, 24))
-        self.stop_button.clicked.connect(self.stop_and_transcribe)
-        self.stop_button.setEnabled(False)
-        controls.addWidget(self.stop_button)
+            self.stop_button = QtWidgets.QPushButton("Stop")
+            self.stop_button.setIcon(self.style().standardIcon(QtWidgets.QStyle.SP_MediaStop))
+            self.stop_button.setIconSize(QtCore.QSize(24, 24))
+            self.stop_button.clicked.connect(self.stop_and_transcribe)
+            self.stop_button.setEnabled(False)
+            controls.addWidget(self.stop_button)
 
-        self.cancel_button = QtWidgets.QPushButton("Cancel")
-        self.cancel_button.setIcon(self.style().standardIcon(QtWidgets.QStyle.SP_DialogCancelButton))
-        self.cancel_button.setIconSize(QtCore.QSize(24, 24))
-        self.cancel_button.clicked.connect(self.cancel_recording)
-        self.cancel_button.setEnabled(False)
-        controls.addWidget(self.cancel_button)
+            self.cancel_button = QtWidgets.QPushButton("Cancel")
+            self.cancel_button.setIcon(self.style().standardIcon(QtWidgets.QStyle.SP_DialogCancelButton))
+            self.cancel_button.setIconSize(QtCore.QSize(24, 24))
+            self.cancel_button.clicked.connect(self.cancel_recording)
+            self.cancel_button.setEnabled(False)
+            controls.addWidget(self.cancel_button)
 
-        layout.addLayout(controls)
+            layout.addLayout(controls)
+        else:
+            self.stop_button = None
+            self.cancel_button = None
 
         self.status_label = QtWidgets.QLabel("Tap Start to capture audio with SoundVoice.")
         self.status_label.setWordWrap(True)
         layout.addWidget(self.status_label)
 
-        if not SOUNDVOICE_OK:
-            self.status_label.setText("SoundVoice requires the optional 'sounddevice' package.")
+        if not self._soundvoice_available:
+            self.status_label.setText(
+                "Recording uses the default microphone backend. Install 'sounddevice' to enable SoundVoice controls."
+            )
 
         self.setLayout(layout)
         self._update_controls()
@@ -121,13 +169,7 @@ class VoiceInputWidget(QtWidgets.QWidget):
     def _handle_primary_press(self):
         if self._transcribing:
             return
-        if not SOUNDVOICE_OK:
-            self.voice_button.setChecked(False)
-            QtWidgets.QMessageBox.warning(
-                self,
-                "SoundVoice",
-                "SoundVoice is unavailable. Install the 'sounddevice' package to enable recording.",
-            )
+        if not self._soundvoice_available or self.recorder is None:
             return
 
         if not self._session_active:
@@ -138,6 +180,8 @@ class VoiceInputWidget(QtWidgets.QWidget):
             self._pause_recording()
 
     def _begin_recording(self) -> None:
+        if self.recorder is None:
+            return
         try:
             self.recorder.start()
         except Exception as exc:
@@ -152,6 +196,8 @@ class VoiceInputWidget(QtWidgets.QWidget):
         self._update_controls()
 
     def _pause_recording(self) -> None:
+        if self.recorder is None:
+            return
         try:
             self.recorder.pause()
         except Exception as exc:
@@ -164,6 +210,8 @@ class VoiceInputWidget(QtWidgets.QWidget):
         self._update_controls()
 
     def _resume_recording(self) -> None:
+        if self.recorder is None:
+            return
         try:
             self.recorder.resume()
         except Exception as exc:
@@ -182,6 +230,8 @@ class VoiceInputWidget(QtWidgets.QWidget):
         self._finish_recording(finalize=False)
 
     def _finish_recording(self, finalize: bool):
+        if not self._soundvoice_available or self.recorder is None:
+            return
         if not self._session_active:
             return
         QtWidgets.QApplication.processEvents()
@@ -195,7 +245,8 @@ class VoiceInputWidget(QtWidgets.QWidget):
             QtWidgets.QMessageBox.warning(self, "SoundVoice", f"Could not stop recording: {e}")
         self._session_active = False
         self._is_paused = False
-        self.voice_button.setChecked(False)
+        if self.voice_button.isCheckable():
+            self.voice_button.setChecked(False)
         self._set_record_button_state()
         self._update_controls()
 
@@ -221,6 +272,8 @@ class VoiceInputWidget(QtWidgets.QWidget):
         self._launch_transcription(wav_bytes)
 
     def _launch_transcription(self, wav_bytes: bytes) -> None:
+        if not wav_bytes:
+            return
         worker = _TranscriptionWorker(wav_bytes, self.language)
         thread = QtCore.QThread(self)
         worker.moveToThread(thread)
@@ -253,7 +306,17 @@ class VoiceInputWidget(QtWidgets.QWidget):
         QtWidgets.QMessageBox.warning(self, "SoundVoice", detail)
 
     def _set_record_button_state(self):
-        if self._transcribing:
+        if not self._soundvoice_available:
+            if self._transcribing:
+                state = "processing"
+                icon = self._processing_icon
+                text = "Listening…"
+            else:
+                state = "idle"
+                icon = self._mic_icon
+                text = "Record Again" if self._has_recorded else "Start Recording"
+            checked = False
+        elif self._transcribing:
             state = "processing"
             icon = self._processing_icon
             text = "Transcribing…"
@@ -277,14 +340,16 @@ class VoiceInputWidget(QtWidgets.QWidget):
         self.voice_button.setProperty("recordState", state)
         self.voice_button.setIcon(icon)
         self.voice_button.setText(text)
-        self.voice_button.setChecked(checked)
+        if self.voice_button.isCheckable():
+            self.voice_button.setChecked(checked)
         self.voice_button.style().unpolish(self.voice_button)
         self.voice_button.style().polish(self.voice_button)
 
     def _update_controls(self) -> None:
         self.voice_button.setEnabled(not self._transcribing)
-        self.stop_button.setEnabled(self._session_active and not self._transcribing)
-        self.cancel_button.setEnabled(self._session_active and not self._transcribing)
+        if self._soundvoice_available and self.stop_button and self.cancel_button:
+            self.stop_button.setEnabled(self._session_active and not self._transcribing)
+            self.cancel_button.setEnabled(self._session_active and not self._transcribing)
 
     def _apply_record_button_style(self):
         self.voice_button.setStyleSheet(
@@ -334,6 +399,45 @@ class VoiceInputWidget(QtWidgets.QWidget):
             }
         """
         )
+
+    def _start_basic_capture(self) -> None:
+        if self._transcribing:
+            return
+        self._transcribing = True
+        self.status_label.setText("Listening… speak now.")
+        self._set_record_button_state()
+        self._update_controls()
+
+        worker = _MicrophoneWorker(self.language)
+        thread = QtCore.QThread(self)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.finished.connect(self._on_basic_capture_succeeded)
+        worker.failed.connect(self._on_basic_capture_failed)
+        worker.finished.connect(thread.quit)
+        worker.failed.connect(thread.quit)
+        worker.finished.connect(worker.deleteLater)
+        worker.failed.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.start()
+        self._transcription_thread = thread
+
+    def _on_basic_capture_succeeded(self, text: str) -> None:
+        self._transcription_thread = None
+        self._transcribing = False
+        self._has_recorded = True
+        self.status_label.setText("Transcription complete.")
+        self._set_record_button_state()
+        self._update_controls()
+        self.textReady.emit(text)
+
+    def _on_basic_capture_failed(self, status_text: str, detail: str) -> None:
+        self._transcription_thread = None
+        self._transcribing = False
+        self.status_label.setText(status_text)
+        self._set_record_button_state()
+        self._update_controls()
+        QtWidgets.QMessageBox.warning(self, "Voice Input", detail)
 
 
 # ------------------- Example Usage -------------------


### PR DESCRIPTION
## Summary
- restyle the primary record control as a large toggle button with dynamic icons and colors for start versus stop states
- keep the toggle in sync with recording outcomes so users can quickly stop recording or retry without awkward states

## Testing
- python -m compileall -f SmartDoctorOrganizerAgent/widgets/voice_input_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68ca97d17c6483289a4b80bc25182d69